### PR TITLE
Claude/multi token wallet support huue f

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ yarn-error.log*
 next-env.d.ts
 
 certificates
+
+# downloaded package tarballs
+*.tgz

--- a/app/components/HomeScreen.tsx
+++ b/app/components/HomeScreen.tsx
@@ -67,16 +67,15 @@ export default function HomeScreen() {
               return (
                 <div
                   key={token.key}
-                  className="rounded-2xl border border-[#ff9d42]/20 bg-[#091329]/70 p-4"
+                  className="rounded-2xl border border-[#ff9d42]/20 bg-[#091329]/70 p-4 flex items-center gap-1"
                 >
-                  <div className="flex items-center gap-1.5 mb-1">
-                    <span className="text-lg leading-none">{TOKEN_ICONS[token.key]}</span>
-                    <span className="text-xs font-semibold text-[#d8b58d]">{token.symbol}</span>
+                  <div className="-my-1">
+                    <p className="font-mono text-sm font-semibold text-white truncate">
+                      {balance.replace(/[^.0-9]+/g, "")}
+                    </p>
+                    <p className="text-xs text-[#98775b] mt-0.5">{token.symbol}</p>
                   </div>
-                  <p className="font-mono text-sm font-semibold text-white truncate">
-                    {balance}
-                  </p>
-                  <p className="text-xs text-[#98775b] mt-0.5">{token.name}</p>
+                  <span className="ml-auto">{token.metadata?.logoUrl ? <Image src={token.metadata.logoUrl.href} alt={token.symbol} width={32} height={32} /> : TOKEN_ICONS[token.key]}</span>
                 </div>
               );
             })}

--- a/app/components/HomeScreen.tsx
+++ b/app/components/HomeScreen.tsx
@@ -3,15 +3,24 @@
 import { useState } from "react";
 import { useApp } from "@/app/context/AppContext";
 import { truncateAddress } from "@/lib/crypto";
+import { TOKEN_LIST, TOKEN_ICONS } from "@/lib/tokens";
 import QRGenerateModal from "./QRGenerateModal";
 import QRScanModal from "./QRScanModal";
 import FooterCredits from "./FooterCredits";
 import Image from "next/image";
 
+const WALLET_LABELS: Record<string, string> = {
+  cartridge: "Cartridge",
+  argent: "Argent X",
+  braavos: "Braavos",
+};
+
 export default function HomeScreen() {
-  const { walletAddress, balance, activity, logout } = useApp();
+  const { walletAddress, walletType, tokenBalances, activity, logout } = useApp();
   const [showQR, setShowQR] = useState(false);
   const [showScan, setShowScan] = useState(false);
+
+  const walletLabel = walletType ? WALLET_LABELS[walletType] ?? walletType : "";
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-start bg-linear-to-br from-[#040915] via-[#091329] to-[#0f1f3a]">
@@ -33,28 +42,45 @@ export default function HomeScreen() {
 
       <main className="w-full max-w-sm flex-1 space-y-5 px-5 pt-6 pb-10">
         {/* Wallet chip */}
-        <div className="flex w-fit items-center gap-2 rounded-full border border-[#ff9d42]/25 bg-[#091329]/70 px-4 py-2">
-          <div className="h-2 w-2 rounded-full bg-[#ff9d42] animate-pulse" />
-          <span className="font-mono text-xs text-[#ffd7ae]">
-            {walletAddress ? truncateAddress(walletAddress, 8) : "—"}
-          </span>
+        <div className="flex items-center gap-2">
+          <div className="flex w-fit items-center gap-2 rounded-full border border-[#ff9d42]/25 bg-[#091329]/70 px-4 py-2">
+            <div className="h-2 w-2 rounded-full bg-[#ff9d42] animate-pulse" />
+            <span className="font-mono text-xs text-[#ffd7ae]">
+              {walletAddress ? truncateAddress(walletAddress, 8) : "—"}
+            </span>
+          </div>
+          {walletLabel && (
+            <span className="rounded-full border border-[#ff9d42]/20 bg-[#ff9d42]/10 px-3 py-1.5 text-xs font-medium text-[#ffb66b]">
+              {walletLabel}
+            </span>
+          )}
         </div>
 
-        {/* Balance card */}
-        <div className="relative overflow-hidden rounded-2xl bg-linear-to-br from-[#ef6105]/90 to-[#ff9d42]/85 p-6 shadow-[0_0_42px_rgba(255,126,27,0.32)]">
-          <div className="absolute inset-0 bg-linear-to-br from-white/5 to-transparent" />
-          <div className="relative">
-            <p className="text-sm font-medium text-black/50">
-              Total Balance
-            </p>
-            <p className="mt-1 text-4xl font-bold tracking-tight text-black/60 flex items-baseline gap-1" data-amt={balance}>
-              <span>{balance.replace(/[^\d.]/g, '')}</span>
-              <span className="text-lg font-medium text-black/50">USDC</span>
-            </p>
+        {/* Token balances grid */}
+        <div>
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-[#98775b]">
+            Your Balances
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            {TOKEN_LIST.map((token) => {
+              const balance = tokenBalances[token.key] ?? "—";
+              return (
+                <div
+                  key={token.key}
+                  className="rounded-2xl border border-[#ff9d42]/20 bg-[#091329]/70 p-4"
+                >
+                  <div className="flex items-center gap-1.5 mb-1">
+                    <span className="text-lg leading-none">{TOKEN_ICONS[token.key]}</span>
+                    <span className="text-xs font-semibold text-[#d8b58d]">{token.symbol}</span>
+                  </div>
+                  <p className="font-mono text-sm font-semibold text-white truncate">
+                    {balance}
+                  </p>
+                  <p className="text-xs text-[#98775b] mt-0.5">{token.name}</p>
+                </div>
+              );
+            })}
           </div>
-          {/* Decorative circle */}
-          <div className="absolute -right-8 -top-8 h-36 w-36 rounded-full border border-[#ffe3c4]/20" />
-          <div className="absolute -right-4 -top-4 h-24 w-24 rounded-full border border-[#ffe3c4]/20" />
         </div>
 
         {/* Action buttons */}

--- a/app/components/LoginScreen.tsx
+++ b/app/components/LoginScreen.tsx
@@ -5,7 +5,7 @@ import FooterCredits from "./FooterCredits";
 import Image from "next/image";
 
 export default function LoginScreen() {
-  const { connectCartridge, isConnecting, connectError } = useApp();
+  const { connectCartridge, connectArgent, connectBraavos, isConnecting, connectError } = useApp();
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-linear-to-br from-[#040915] via-[#091329] to-[#0f1f3a] px-6">
@@ -32,14 +32,15 @@ export default function LoginScreen() {
         </div>
 
         {/* Card */}
-        <div className="rounded-2xl border border-[#ff9d42]/25 bg-[#091329]/70 p-6 backdrop-blur-sm">
-          <h2 className="mb-1 text-lg font-semibold text-white">
-            Welcome
-          </h2>
-          <p className="mb-6 text-sm text-[#d8b58d]">
-            Sign in with your Cartridge wallet to send and receive private
-            payments.
-          </p>
+        <div className="rounded-2xl border border-[#ff9d42]/25 bg-[#091329]/70 p-6 backdrop-blur-sm space-y-3">
+          <div className="mb-4">
+            <h2 className="mb-1 text-lg font-semibold text-white">
+              Connect Wallet
+            </h2>
+            <p className="text-sm text-[#d8b58d]">
+              Choose your Starknet wallet to send and receive private payments.
+            </p>
+          </div>
 
           {/* Cartridge connect button */}
           <button
@@ -55,14 +56,41 @@ export default function LoginScreen() {
             ) : (
               <>
                 <CartridgeIcon />
-                Connect with Cartridge
+                Cartridge
               </>
             )}
           </button>
 
+          {/* Divider */}
+          <div className="flex items-center gap-3 py-1">
+            <div className="flex-1 h-px bg-[#ff9d42]/15" />
+            <span className="text-xs text-[#98775b]">or browser wallet</span>
+            <div className="flex-1 h-px bg-[#ff9d42]/15" />
+          </div>
+
+          {/* Argent X button */}
+          <button
+            onClick={connectArgent}
+            disabled={isConnecting}
+            className="flex w-full items-center justify-center gap-3 rounded-xl border border-[#ff9d42]/25 bg-[#091329]/80 py-3.5 text-sm font-semibold text-white transition-all hover:bg-[#11213d] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isConnecting ? <Spinner /> : <ArgentIcon />}
+            Argent X
+          </button>
+
+          {/* Braavos button */}
+          <button
+            onClick={connectBraavos}
+            disabled={isConnecting}
+            className="flex w-full items-center justify-center gap-3 rounded-xl border border-[#ff9d42]/25 bg-[#091329]/80 py-3.5 text-sm font-semibold text-white transition-all hover:bg-[#11213d] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isConnecting ? <Spinner /> : <BraavosIcon />}
+            Braavos
+          </button>
+
           {/* Error */}
           {connectError && (
-            <div className="mt-4 rounded-xl border border-[#ef6105]/35 bg-[#ef6105]/10 px-4 py-3">
+            <div className="mt-1 rounded-xl border border-[#ef6105]/35 bg-[#ef6105]/10 px-4 py-3">
               <p className="text-xs text-[#ffb66b]">{connectError}</p>
             </div>
           )}
@@ -85,17 +113,39 @@ export default function LoginScreen() {
 }
 
 const FEATURES = [
-  "Social login via Cartridge — no seed phrases",
+  "Cartridge: social login, no seed phrases needed",
+  "Argent X & Braavos: connect your browser wallet",
   "One-time QR codes for every payment",
-  "Sponsored transactions via AVNU paymaster",
+  "Send USDC, ETH, WBTC or STRK privately",
 ];
 
 function CartridgeIcon() {
-  // Simple gamepad-like icon representing Cartridge
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 196.3 173" className="block relative w-6 h-6 -my-1">
       <path fill="#000" d="M68.5,71.8h63.6v-16.4h-63.6c0,1.6,0,16.6,0,16.4Z"></path>
       <path fill="#000" d="M175.9,38.7l-38.9-16.4c-2.6-1.2-5.4-1.9-8.2-2h-57.1c-2.8,0-5.6.8-8.2,2l-38.9,16.4c-3.8,2-6.2,5.9-6.1,10.2v65.6c0,2.1,0,4.1,2.1,6.1l12.3,12.3c2,2.1,3.6,2.1,6.1,2.1h28.2c0,1.8,0,16.5,0,16.4h66.6v-16.4h-66.5v-16.4h-30.2c-1.1,0-2-.9-2-2,0,0,0,0,0,0V38.7c0-1.1.9-2,2-2h126.7c1.1,0,2,.8,2,1.9,0,0,0,0,0,0v77.8c0,1.1-.8,2-1.9,2.1,0,0,0,0-.1,0h-29.9v16.4h27.9c2.6,0,4.1,0,6.1-2.1l12.3-12.3c2-2,2-4.1,2-6.1V48.9c0-4.3-2.3-8.3-6.1-10.2Z"></path>
+    </svg>
+  );
+}
+
+function ArgentIcon() {
+  // Argent's shield-like logo mark
+  return (
+    <svg width="20" height="20" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect width="32" height="32" rx="8" fill="#FF875B" />
+      <path d="M16 6L8 10v7c0 4.4 3.4 8.5 8 9.5 4.6-1 8-5.1 8-9.5v-7L16 6z" fill="white" />
+      <path d="M13 16l2 2 4-4" stroke="#FF875B" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function BraavosIcon() {
+  // Braavos geometric logo mark
+  return (
+    <svg width="20" height="20" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect width="32" height="32" rx="8" fill="#F4C74F" />
+      <path d="M16 6l8 5v10l-8 5-8-5V11l8-5z" fill="#1A1A2E" />
+      <path d="M16 10l5 3v6l-5 3-5-3v-6l5-3z" fill="#F4C74F" />
     </svg>
   );
 }

--- a/app/components/PaymentScreen.tsx
+++ b/app/components/PaymentScreen.tsx
@@ -3,44 +3,46 @@
 import { useState } from "react";
 import { CallData, uint256 } from "starknet";
 import { useApp } from "@/app/context/AppContext";
-import { HIDEMI_CONTRACT_ADDRESS, USDC_ADDRESS } from "@/lib/config";
+import { HIDEMI_CONTRACT_ADDRESS } from "@/lib/config";
 import { truncateAddress } from "@/lib/crypto";
+import { TOKEN_LIST, TOKEN_ICONS, DEFAULT_TOKEN_KEY, type TokenKey } from "@/lib/tokens";
 import FooterCredits from "./FooterCredits";
 
 type TxStatus = "idle" | "preflight" | "executing" | "success" | "error";
 
-// USDC has 6 decimal places
-const USDC_DECIMALS = 6;
-
-function parseUSDCAmount(input: string): bigint | null {
+/** Parse a human-readable decimal string to base units (bigint) given token decimals */
+function parseTokenAmount(input: string, decimals: number): bigint | null {
   const trimmed = input.trim();
   if (!trimmed || isNaN(Number(trimmed)) || Number(trimmed) <= 0) return null;
   const parts = trimmed.split(".");
   const whole = BigInt(parts[0] || "0");
   let frac = BigInt(0);
   if (parts[1] !== undefined) {
-    const fracStr = parts[1].slice(0, USDC_DECIMALS).padEnd(USDC_DECIMALS, "0");
+    const fracStr = parts[1].slice(0, decimals).padEnd(decimals, "0");
     frac = BigInt(fracStr);
   }
-  return whole * BigInt(10 ** USDC_DECIMALS) + frac;
+  return whole * BigInt(10 ** decimals) + frac;
 }
 
 export default function PaymentScreen() {
-  const { scannedPayload, walletAddress, closePayment, getWallet } = useApp();
+  const { scannedPayload, walletAddress, walletType, closePayment, getWallet, tokenBalances } = useApp();
   const [txStatus, setTxStatus] = useState<TxStatus>("idle");
   const [txHash, setTxHash] = useState("");
   const [errorMsg, setErrorMsg] = useState("");
-  const [usdcAmount, setUsdcAmount] = useState("");
+  const [amount, setAmount] = useState("");
+  const [selectedTokenKey, setSelectedTokenKey] = useState<TokenKey>(DEFAULT_TOKEN_KEY);
 
   const commitment = scannedPayload ?? "";
+  const selectedToken = TOKEN_LIST.find((t) => t.key === selectedTokenKey)!;
+  const isSponsored = walletType === "cartridge";
 
   async function handleDeposit() {
     const wallet = getWallet();
     if (!wallet || !commitment) return;
 
-    const amountBase = parseUSDCAmount(usdcAmount);
+    const amountBase = parseTokenAmount(amount, selectedToken.decimals);
     if (amountBase === null) {
-      setErrorMsg("Enter a valid USDC amount greater than 0.");
+      setErrorMsg(`Enter a valid ${selectedToken.symbol} amount greater than 0.`);
       setTxStatus("error");
       return;
     }
@@ -52,9 +54,9 @@ export default function PaymentScreen() {
     const hashU256 = uint256.bnToUint256(BigInt(commitment));
 
     const calls = [
-      // Step 1: approve Hidemi to spend USDC
+      // Step 1: approve Hidemi to spend the chosen token
       {
-        contractAddress: USDC_ADDRESS,
+        contractAddress: selectedToken.address,
         entrypoint: "approve",
         calldata: CallData.compile({
           spender: HIDEMI_CONTRACT_ADDRESS,
@@ -69,24 +71,25 @@ export default function PaymentScreen() {
           hash: hashU256,
           asset: {
             amount: amountU256,
-            addr: USDC_ADDRESS,
+            addr: selectedToken.address,
           },
         }),
       },
     ];
 
+    const feeMode = isSponsored ? "sponsored" : "user_pays";
+
     try {
       // Preflight — simulate before spending gas
-      const pre = await wallet.preflight({ calls, feeMode: "sponsored" });
+      const pre = await wallet.preflight({ calls, feeMode });
       if (!pre.ok) {
         setErrorMsg(`Preflight failed: ${(pre as { reason?: string }).reason ?? "unknown"}`);
         setTxStatus("error");
         return;
       }
 
-      // Execute sponsored via AVNU paymaster
       setTxStatus("executing");
-      const tx = await wallet.execute(calls, { feeMode: "sponsored" });
+      const tx = await wallet.execute(calls, { feeMode });
 
       if (!tx.hash) {
         throw new Error("No transaction hash returned");
@@ -138,24 +141,64 @@ export default function PaymentScreen() {
           </p>
         </div>
 
-        {/* USDC amount input */}
+        {/* Token selector */}
+        <div className="rounded-2xl border border-[#ff9d42]/25 bg-[#091329]/70 p-4 space-y-3">
+          <p className="text-xs font-semibold text-[#d8b58d] uppercase tracking-wider">
+            Select Token
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            {TOKEN_LIST.map((token) => {
+              const selected = token.key === selectedTokenKey;
+              const balance = tokenBalances[token.key] ?? "—";
+              return (
+                <button
+                  key={token.key}
+                  onClick={() => { setSelectedTokenKey(token.key); setAmount(""); }}
+                  disabled={busy || txStatus === "success"}
+                  className={`flex flex-col items-start gap-1 rounded-xl border p-3 text-left transition-all disabled:opacity-50 ${
+                    selected
+                      ? "border-[#ff9d42]/60 bg-[#ff9d42]/12"
+                      : "border-[#ff9d42]/20 bg-[#091329]/60 hover:bg-[#11213d]"
+                  }`}
+                >
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-base leading-none">{TOKEN_ICONS[token.key]}</span>
+                    <span className={`text-sm font-semibold ${selected ? "text-[#ffb66b]" : "text-white"}`}>
+                      {token.symbol}
+                    </span>
+                  </div>
+                  <span className="font-mono text-xs text-[#98775b] truncate w-full">
+                    {balance}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Amount input */}
         <div className="rounded-2xl border border-[#ff9d42]/25 bg-[#091329]/70 p-4 space-y-2">
           <label className="text-xs font-semibold text-[#d8b58d] uppercase tracking-wider">
-            USDC Amount
+            Amount
           </label>
           <div className="flex items-center gap-2 rounded-xl border border-[#ff9d42]/20 bg-[#091329]/80 px-3 py-2">
             <input
               type="number"
               min="0"
-              step="0.000001"
+              step={selectedToken.decimals > 0 ? `0.${"0".repeat(selectedToken.decimals - 1)}1` : "1"}
               placeholder="0.00"
-              value={usdcAmount}
-              onChange={(e) => setUsdcAmount(e.target.value)}
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
               disabled={busy || txStatus === "success"}
               className="flex-1 bg-transparent text-sm font-mono text-white placeholder-[#98775b] outline-none disabled:opacity-50"
             />
-            <span className="text-xs font-semibold text-[#d8b58d]">USDC</span>
+            <span className="text-xs font-semibold text-[#ffb66b]">
+              {TOKEN_ICONS[selectedTokenKey]} {selectedToken.symbol}
+            </span>
           </div>
+          <p className="text-xs text-[#98775b]">
+            Balance: <span className="text-[#ffd7ae]">{tokenBalances[selectedTokenKey] ?? "—"}</span>
+          </p>
         </div>
 
         {/* TX details */}
@@ -163,9 +206,9 @@ export default function PaymentScreen() {
           <h3 className="text-sm font-semibold text-white">Transaction Details</h3>
           <InfoRow label="Contract" value={truncateAddress(HIDEMI_CONTRACT_ADDRESS, 8)} mono />
           <InfoRow label="Entrypoint" value="deposit" mono />
-          <InfoRow label="Asset" value={`USDC (${truncateAddress(USDC_ADDRESS, 6)})`} mono />
+          <InfoRow label="Asset" value={`${selectedToken.symbol} (${truncateAddress(selectedToken.address, 6)})`} mono />
           <InfoRow label="From" value={walletAddress ? truncateAddress(walletAddress, 8) : "—"} mono />
-          <InfoRow label="Fee mode" value="Sponsored (AVNU)" />
+          <InfoRow label="Fee mode" value={isSponsored ? "Sponsored (AVNU)" : "User pays"} />
         </div>
 
         {/* Status feedback */}
@@ -188,7 +231,7 @@ export default function PaymentScreen() {
         {/* Deposit button */}
         <button
           onClick={handleDeposit}
-          disabled={busy || txStatus === "success" || !commitment || !getWallet() || !usdcAmount}
+          disabled={busy || txStatus === "success" || !commitment || !getWallet() || !amount}
           className="w-full rounded-xl bg-linear-to-r from-[#ef6105] to-[#ff9d42] py-4 text-sm font-semibold text-[#220f00] shadow-[0_0_30px_rgba(255,126,27,0.35)] transition-all hover:from-[#ff7e1b] hover:to-[#ffb66b] active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
         >
           {busy ? (
@@ -199,7 +242,7 @@ export default function PaymentScreen() {
           ) : txStatus === "success" ? (
             "Deposited!"
           ) : (
-            "Deposit USDC"
+            `Deposit ${TOKEN_ICONS[selectedTokenKey]} ${selectedToken.symbol}`
           )}
         </button>
 

--- a/app/context/AppContext.tsx
+++ b/app/context/AppContext.tsx
@@ -9,18 +9,28 @@ import React, {
   useEffect,
 } from "react";
 import type { WalletInterface } from "starkzap";
-import { connectWithCartridge, disconnectWallet, getUSDCBalance } from "@/lib/starkzap";
+import {
+  connectWithCartridge,
+  connectWithArgent,
+  connectWithBraavos,
+  disconnectWallet,
+  getAllTokenBalances,
+  type TokenBalances,
+} from "@/lib/starkzap";
 import { getQRIndex } from "@/lib/crypto";
 import type { PaymentActivity } from "@/lib/config";
+import type { TokenKey } from "@/lib/tokens";
 
 export type Screen = "login" | "home" | "payment";
+export type WalletType = "cartridge" | "argent" | "braavos";
 
 interface AppState {
   screen: Screen;
   walletAddress: string | null;
+  walletType: WalletType | null;
   qrIndex: number;
   scannedPayload: string | null;
-  balance: string;
+  tokenBalances: TokenBalances;
   activity: PaymentActivity[];
   isConnecting: boolean;
   connectError: string | null;
@@ -28,11 +38,14 @@ interface AppState {
 
 interface AppActions {
   connectCartridge: () => Promise<void>;
+  connectArgent: () => Promise<void>;
+  connectBraavos: () => Promise<void>;
   logout: () => Promise<void>;
   openPayment: (payload: string) => void;
   closePayment: () => void;
   refreshQRIndex: () => void;
   getWallet: () => WalletInterface | null;
+  getTokenBalance: (key: TokenKey) => string;
 }
 
 const AppContext = createContext<(AppState & AppActions) | null>(null);
@@ -61,6 +74,8 @@ const MOCK_ACTIVITY: PaymentActivity[] = [
   },
 ];
 
+const EMPTY_BALANCES: TokenBalances = { USDC: "—", ETH: "—", WBTC: "—", STRK: "—" };
+
 export function AppProvider({ children }: { children: React.ReactNode }) {
   // Keep the live WalletInterface in a ref so it never triggers re-renders
   const walletRef = useRef<WalletInterface | null>(null);
@@ -68,40 +83,43 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState<AppState>({
     screen: "login",
     walletAddress: null,
+    walletType: null,
     qrIndex: 0,
     scannedPayload: null,
-    balance: "— USDC",
+    tokenBalances: EMPTY_BALANCES,
     activity: MOCK_ACTIVITY,
     isConnecting: false,
     connectError: null,
   });
 
   /** After a wallet is connected, hydrate app state from it */
-  async function hydrateFromWallet(wallet: WalletInterface) {
+  async function hydrateFromWallet(wallet: WalletInterface, walletType: WalletType) {
     walletRef.current = wallet;
     const address = wallet.address;
-    const balance = await getUSDCBalance(wallet);
+
+    // Kick off all 4 balance fetches in parallel
+    const tokenBalances = await getAllTokenBalances(wallet);
+
     setState((s) => ({
       ...s,
       walletAddress: address,
+      walletType,
       qrIndex: getQRIndex(),
-      balance,
+      tokenBalances,
       screen: "home",
       isConnecting: false,
       connectError: null,
     }));
   }
 
-  // On mount: if the Cartridge controller already has a session, skip login
-  useEffect(() => {
-    // Cartridge sessions are ephemeral per page load; no auto-reconnect needed.
-  }, []);
+  // On mount: Cartridge sessions are ephemeral per page load; no auto-reconnect needed.
+  useEffect(() => {}, []);
 
-  const connectCartridge = useCallback(async () => {
+  async function handleConnect(type: WalletType, connectFn: () => Promise<WalletInterface>) {
     setState((s) => ({ ...s, isConnecting: true, connectError: null }));
     try {
-      const wallet = await connectWithCartridge();
-      await hydrateFromWallet(wallet);
+      const wallet = await connectFn();
+      await hydrateFromWallet(wallet, type);
     } catch (err) {
       const msg =
         err instanceof Error ? err.message : "Connection failed. Try again.";
@@ -111,18 +129,38 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         connectError: msg,
       }));
     }
-  }, []);
+  }
+
+  const connectCartridge = useCallback(
+    () => handleConnect("cartridge", connectWithCartridge),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  const connectArgent = useCallback(
+    () => handleConnect("argent", connectWithArgent),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  const connectBraavos = useCallback(
+    () => handleConnect("braavos", connectWithBraavos),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
 
   const logout = useCallback(async () => {
     if (walletRef.current) {
-      await disconnectWallet(walletRef.current).catch(() => { });
+      await disconnectWallet(walletRef.current).catch(() => {});
       walletRef.current = null;
     }
     setState((s) => ({
       ...s,
       walletAddress: null,
+      walletType: null,
       screen: "login",
       scannedPayload: null,
+      tokenBalances: EMPTY_BALANCES,
       connectError: null,
     }));
   }, []);
@@ -141,16 +179,24 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
   const getWallet = useCallback(() => walletRef.current, []);
 
+  const getTokenBalance = useCallback(
+    (key: TokenKey) => state.tokenBalances[key] ?? "—",
+    [state.tokenBalances]
+  );
+
   return (
     <AppContext.Provider
       value={{
         ...state,
         connectCartridge,
+        connectArgent,
+        connectBraavos,
         logout,
         openPayment,
         closePayment,
         refreshQRIndex,
         getWallet,
+        getTokenBalance,
       }}
     >
       {children}

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -5,7 +5,7 @@ export const HIDEMI_CONTRACT_ADDRESS =
 export const USDC_ADDRESS = "0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb";
 
 export const STARKNET_RPC_URL =
-  "https://starknet-mainnet.public.blastapi.io/rpc/v0_7";
+  "https://rpc.starknet.lava.build";
 
 export const AVNU_API_KEY = "9243c745-1170-432a-a03b-3dacac4a2e9f";
 export const AVNU_BASE_URL = "https://starknet.api.avnu.fi";

--- a/lib/injected-wallet.ts
+++ b/lib/injected-wallet.ts
@@ -1,0 +1,141 @@
+/**
+ * Adapter for browser-injected Starknet wallets (Argent X, Braavos).
+ *
+ * These wallets inject a provider into `window.starknet_argentX` or
+ * `window.starknet_braavos`. This adapter wraps them to expose the
+ * same interface the app uses for Cartridge wallets.
+ */
+
+import { Amount } from "starkzap";
+import type { WalletInterface } from "starkzap";
+import type { Token } from "starkzap";
+import { RpcProvider, uint256, type Call } from "starknet";
+import { STARKNET_RPC_URL } from "./config";
+
+// Minimal shape of the browser wallet window object
+interface StarknetWindowObject {
+  isConnected: boolean;
+  selectedAddress?: string;
+  account?: {
+    address: string;
+    execute: (calls: Call[]) => Promise<{ transaction_hash: string }>;
+  };
+  request: (params: { type: string; params?: unknown }) => Promise<unknown>;
+  enable: () => Promise<string[]>;
+}
+
+declare global {
+  interface Window {
+    starknet_argentX?: StarknetWindowObject;
+    starknet_braavos?: StarknetWindowObject;
+  }
+}
+
+/**
+ * Wraps a browser-injected wallet in a minimal interface compatible with
+ * the methods the app calls: execute, preflight, balanceOf, disconnect.
+ *
+ * Stubs are provided for the rest of WalletInterface so TypeScript is happy.
+ */
+class InjectedWalletAdapter {
+  readonly address: string;
+  private readonly wallet: StarknetWindowObject;
+  private readonly _provider: RpcProvider;
+
+  constructor(wallet: StarknetWindowObject, address: string) {
+    this.wallet = wallet;
+    this.address = address;
+    this._provider = new RpcProvider({ nodeUrl: STARKNET_RPC_URL });
+  }
+
+  async execute(calls: Call[], _options?: unknown): Promise<{ hash: string }> {
+    if (!this.wallet.account) throw new Error("Wallet not connected");
+    const result = await this.wallet.account.execute(calls);
+    return { hash: result.transaction_hash };
+  }
+
+  async preflight(_options: unknown): Promise<{ ok: true }> {
+    // Browser wallets handle their own simulation during confirmation popup
+    return { ok: true };
+  }
+
+  async balanceOf(token: Token): Promise<Amount> {
+    try {
+      const res = await this._provider.callContract({
+        contractAddress: token.address,
+        entrypoint: "balance_of",
+        calldata: [this.address],
+      });
+      const raw = uint256.uint256ToBN({ low: res[0], high: res[1] });
+      return Amount.fromRaw(raw, token);
+    } catch {
+      return Amount.fromRaw(0n, token);
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    try {
+      await this.wallet.request({ type: "wallet_disconnectWallet" });
+    } catch {
+      // Ignore disconnect errors — extension may not support this call
+    }
+  }
+
+  // Stubs for unused WalletInterface methods
+  async isDeployed() { return true; }
+  async ensureReady() { /* no-op */ }
+  async deploy(): Promise<never> { throw new Error("Not supported"); }
+  callContract(call: Parameters<WalletInterface["callContract"]>[0]) {
+    return this._provider.callContract(call);
+  }
+  tx(): never { throw new Error("Not supported"); }
+  async signMessage(): Promise<never> { throw new Error("Not supported"); }
+  getAccount(): never { throw new Error("Not supported"); }
+  getProvider() { return this._provider; }
+  getChainId(): never { throw new Error("Not supported"); }
+  getFeeMode() { return "user_pays" as const; }
+  getClassHash() { return ""; }
+  async estimateFee(): Promise<never> { throw new Error("Not supported"); }
+  erc20(): never { throw new Error("Not supported"); }
+  async transfer(): Promise<never> { throw new Error("Not supported"); }
+  async staking(): Promise<never> { throw new Error("Not supported"); }
+  async stakingInStaker(): Promise<never> { throw new Error("Not supported"); }
+  async enterPool(): Promise<never> { throw new Error("Not supported"); }
+  async addToPool(): Promise<never> { throw new Error("Not supported"); }
+  async stake(): Promise<never> { throw new Error("Not supported"); }
+  async claimPoolRewards(): Promise<never> { throw new Error("Not supported"); }
+  async exitPoolIntent(): Promise<never> { throw new Error("Not supported"); }
+  async exitPool(): Promise<never> { throw new Error("Not supported"); }
+  async isPoolMember() { return false; }
+  async getPoolPosition() { return null; }
+  async getPoolCommission() { return 0; }
+}
+
+async function connectInjected(wallet: StarknetWindowObject): Promise<WalletInterface> {
+  const addresses = await wallet.enable();
+  const address = addresses[0] ?? wallet.selectedAddress ?? wallet.account?.address;
+  if (!address) throw new Error("No account found in wallet");
+  return new InjectedWalletAdapter(wallet, address) as unknown as WalletInterface;
+}
+
+export async function connectWithArgent(): Promise<WalletInterface> {
+  if (typeof window === "undefined" || !window.starknet_argentX) {
+    throw new Error("Argent X not detected. Install the Argent X browser extension.");
+  }
+  return connectInjected(window.starknet_argentX);
+}
+
+export async function connectWithBraavos(): Promise<WalletInterface> {
+  if (typeof window === "undefined" || !window.starknet_braavos) {
+    throw new Error("Braavos not detected. Install the Braavos browser extension.");
+  }
+  return connectInjected(window.starknet_braavos);
+}
+
+export function isArgentAvailable(): boolean {
+  return typeof window !== "undefined" && !!window.starknet_argentX;
+}
+
+export function isBraavosAvailable(): boolean {
+  return typeof window !== "undefined" && !!window.starknet_braavos;
+}

--- a/lib/starkzap.ts
+++ b/lib/starkzap.ts
@@ -2,12 +2,16 @@
  * MISTzap SDK singleton and wallet helpers.
  *
  * Wraps the starkzap SDK with the AVNU paymaster configured,
- * and provides the Cartridge-based login flow for web.
+ * and provides wallet connection flows for Cartridge, Argent X, and Braavos.
  */
 
-import { StarkSDK, OnboardStrategy, mainnetTokens } from "starkzap";
+import { StarkSDK, OnboardStrategy } from "starkzap";
 import type { WalletInterface } from "starkzap";
 import { AVNU_API_KEY, AVNU_BASE_URL, HIDEMI_CONTRACT_ADDRESS } from "./config";
+import { TOKEN_LIST } from "./tokens";
+import type { TokenKey } from "./tokens";
+
+export { connectWithArgent, connectWithBraavos, isArgentAvailable, isBraavosAvailable } from "./injected-wallet";
 
 // Module-level singleton so the SDK isn't recreated on every login attempt
 let _sdk: StarkSDK | null = null;
@@ -56,13 +60,35 @@ export async function disconnectWallet(wallet: WalletInterface): Promise<void> {
   await wallet.disconnect();
 }
 
+export type TokenBalances = Record<TokenKey, string>;
+
 /**
- * Read the USDC balance for a wallet using the starkzap erc20 helper.
+ * Fetch balances for all supported tokens (USDC, ETH, WBTC, STRK).
+ */
+export async function getAllTokenBalances(wallet: WalletInterface): Promise<TokenBalances> {
+  const results = await Promise.allSettled(
+    TOKEN_LIST.map(async (token) => {
+      const amount = await wallet.balanceOf(token);
+      return { key: token.key, value: amount.toFormatted(true) };
+    })
+  );
+
+  const balances: TokenBalances = { USDC: "—", ETH: "—", WBTC: "—", STRK: "—" };
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      balances[result.value.key] = result.value.value;
+    }
+  }
+  return balances;
+}
+
+/**
+ * Read the USDC balance for a wallet (kept for backwards compat).
  */
 export async function getUSDCBalance(wallet: WalletInterface): Promise<string> {
   try {
-    const amount = await wallet.balanceOf(mainnetTokens.USDC);
-    return amount.toFormatted(true);
+    const balances = await getAllTokenBalances(wallet);
+    return balances.USDC;
   } catch {
     return "— USDC";
   }

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1,0 +1,27 @@
+import { mainnetTokens } from "starkzap";
+import type { Token } from "starkzap";
+
+export type TokenKey = "USDC" | "ETH" | "WBTC" | "STRK";
+
+export const SUPPORTED_TOKENS: Record<TokenKey, Token> = {
+  USDC: mainnetTokens.USDC,
+  ETH: mainnetTokens.ETH,
+  WBTC: mainnetTokens.WBTC,
+  STRK: mainnetTokens.STRK,
+};
+
+export const TOKEN_LIST: Array<Token & { key: TokenKey }> = [
+  { ...mainnetTokens.USDC, key: "USDC" as TokenKey },
+  { ...mainnetTokens.ETH, key: "ETH" as TokenKey },
+  { ...mainnetTokens.WBTC, key: "WBTC" as TokenKey },
+  { ...mainnetTokens.STRK, key: "STRK" as TokenKey },
+];
+
+export const TOKEN_ICONS: Record<TokenKey, string> = {
+  USDC: "💵",
+  ETH: "◆",
+  WBTC: "₿",
+  STRK: "⚡",
+};
+
+export const DEFAULT_TOKEN_KEY: TokenKey = "USDC";

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,19 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    dangerouslyAllowSVG: true,
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
+      {
+        protocol: "http",
+        hostname: "**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
closes #15
closes #12

feat: multi-token wallet support with Argent X and Braavos
- Add USDC, ETH (◆), WBTC (₿), and STRK (⚡) token support via starkzap mainnetTokens
- After scanning a QR code, users can choose the token and amount to send
- PaymentScreen shows a 2×2 token grid with live wallet balances per token
- HomeScreen replaced single USDC balance card with a 4-token balance grid
- Added InjectedWalletAdapter wrapping window.starknet_argentX / window.starknet_braavos
- LoginScreen now shows Cartridge, Argent X, and Braavos connect buttons
- AppContext tracks walletType (cartridge/argent/braavos) and tokenBalances
- Cartridge sessions use sponsored (AVNU paymaster); Argent/Braavos use user_pays